### PR TITLE
Query posts with get_posts instead of custom SQL

### DIFF
--- a/includes/shortcodes/UptrackMapShortcode.php
+++ b/includes/shortcodes/UptrackMapShortcode.php
@@ -24,8 +24,6 @@ class UptrackMapShortCode
 
     private static function collect_posts($routes)
     {
-        global $wpdb;
-
         if (empty($routes)) {
             return [];
         }
@@ -37,17 +35,10 @@ class UptrackMapShortCode
             $post_ids[] = $post_id;
         }
 
-        // Query posts.
-        $posts = $wpdb->get_results(
-            $wpdb->prepare(
-                "SELECT ID, post_title, post_status
-                 FROM {$wpdb->posts}
-                 WHERE ID IN (" .
-                    implode(",", array_fill(0, count($post_ids), "%d")) .
-                    ")",
-                ...$post_ids,
-            ),
-        );
+        $posts = \get_posts([
+            "include" => $post_ids,
+            "numberposts" => -1,
+        ]);
 
         // Map by ID.
         $post_map = [];


### PR DESCRIPTION
Fixes #9 

I initially used custom SQL to try and optimize the query, since we don't need that many fields. However, it looks like when you pass a post object to `get_permalink`, it relies on some fields being present (depending on the site's configuration) which weren't present in my custom SQL query.

This simply switches to using `get_posts` for the sake of simplicity.